### PR TITLE
Unhandled exceptions

### DIFF
--- a/src/nji/NjiApi.cs
+++ b/src/nji/NjiApi.cs
@@ -273,9 +273,6 @@ namespace nji
                 .OpenReadTaskAsync(cancellationToken)
                 .ContinueWith<object>(task =>
                                           {
-                                              if (task.IsFaulted)
-                                                  throw task.Exception.GetBaseException();
-
                                               // todo: handle errors
                                               var response = httpHelper.HttpWebResponse;
                                               if (response.StatusCode == HttpStatusCode.OK)

--- a/src/nji/Program.cs
+++ b/src/nji/Program.cs
@@ -4,6 +4,7 @@
     using System.IO;
     using System.Linq;
     using System.Threading;
+    using System.Net;
 
     class Program
     {
@@ -45,6 +46,16 @@
                 {
                     throw;
                 }
+            }
+            catch (NjiPackageNotFoundException ex)
+            {
+                Console.WriteLine(ex.Message);
+                Environment.Exit(1);
+            }
+            catch (NjiException ex)
+            {
+                Console.WriteLine(ex.Message);
+                Environment.Exit(1);
             }
             finally
             {


### PR DESCRIPTION
Running something like

```
nji install uglifyjs
```

causes the program to crash (package spelled incorrectly), since there are some unhandled exceptions.

`FluentHttp.WebExceptionWrapper` was not handled properly.

I fixed this by catching `NjiPackageNotFoundException` and `NjiException`. I hope I did this correctly, but I'm not sure, since I am not very experienced with C# and .NET. Though it works with unknown package names now. I hope you may find this useful.
